### PR TITLE
fix: correct property casing for session

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -29,7 +29,9 @@ function session (req, res, next) {
   var session = req.cookies.session;
   if (!session) 
     return res.redirect('/');
-  session.response.Message = session.response.Message
+  session.response.Type = session.response.Type ?? session.response.type;
+  session.response.ClientState = session.response.ClientState ?? session.response.clientState;
+  session.response.Message = session.response.Message ?? session.response.message
     .substr(0, 182)
     .replace(/\r\n/g, '<br>')
     .replace(/\n/g, '<br>')


### PR DESCRIPTION
The casing causes some properties of the session object to return `null`, hence crashing the app.